### PR TITLE
[Fix]: add github.ref to concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 # If multiple runs, keep only the last one
 concurrency: 
-  group: ci
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 # We run on push to every branch except main


### PR DESCRIPTION
Add the github.ref to the concurrency group to avoid cancellation between branches