### PR TITLE
fix!: ignore behavior now matches that of git

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Simple nodejs cli which allows you to create and extract zip/tar files with supp
 Install it locally with
 
 ```bash
-npm i https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.6.2/node-zip-cli-0.6.2.tgz
+npm i https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.0/node-zip-cli-0.7.0.tgz
 ```
 
 Or install it globally with
 
 ```bash
-npm i --location=global https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.6.2/node-zip-cli-0.6.2.tgz
+npm i --location=global https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.0/node-zip-cli-0.7.0.tgz
 ```
 
 ### Other version
@@ -204,7 +204,7 @@ Allows you to specify paths that you want to exclude. This option follows the sa
 > For example, providing `*.mjs` will result in the shell replacing it will all the file matching the wildcard, so as the input to the cli, instead of `"*.mjs"` will be provided the whole list (e.g. "rollup.config.mjs", "test.runner.mjs", ...). Instead, providing `"*.mjs"` will behave as expected, providing as input to the cli the pattern `"*.mjs"`
 
 > [!NOTE]
-> Up to the current version (0.6.2) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
+> Up to the current version (0.7.0) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
 
 ###### `--allow-git`
 
@@ -338,7 +338,7 @@ Allows you to specify paths that you want to exclude. This option follows the sa
 > For example, providing `*.mjs` will result in the shell replacing it will all the file matching the wildcard, so as the input to the cli, instead of `"*.mjs"` will be provided the whole list (e.g. "rollup.config.mjs", "test.runner.mjs", ...). Instead, providing `"*.mjs"` will behave as expected, providing as input to the cli the pattern `"*.mjs"`
 
 > [!NOTE]
-> Up to the current version (0.6.2) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
+> Up to the current version (0.7.0) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
 
 ###### `--allow-git`
 
@@ -393,10 +393,15 @@ Simply run this CLI providing to each command all the necessary options.
 This file is meant to be placed in a folder which you plan to zip/tar. It is meant to be used instead of the .gitignore, if the content of the folder is not related to git, or as an extension of the .gitignore, where you can specify additional rules related only to the zip file creation. The .zipignore file follow the same syntax and rules of the traditional .gitignore
 
 > [!NOTE]
-> Up to the current version (0.6.2) the .zipignore builds on top of already existing .gitignore rules, so if you only want to ignore some additional files you **do not need** to copy paste the content of the .gitignore.
+> Up to the current version (0.7.0) the .zipignore builds on top of already existing .gitignore rules, so if you only want to ignore some additional files you **do not need** to copy paste the content of the .gitignore.
+
+> [!NOTE]
+> Since version (0.7.0) the strategy of ignoring `*` and the unignore some paths (e.g. `!test`, `!src`, ...) is supported and behaves like in the gitignore specs. Quoting from [gitignore spces](https://git-scm.com/docs/gitignore): *"It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined. "*.
+>
+> For the same performance reasons and to match git behavior, node-zip-cli doesn’t list excluded directories
 
 > [!WARNING]
 > *Current limitaionts*  
-> Up to the current version (0.6.2) the strategy of ignoring `*` and the not ignore some paths (e.g. `!test`, `!src`, ...) is not supported.
+> Up to the current version (0.7.0) zip/tar and unzip/untar should handle files, directories and symlinks. Though, symlink support is still experimental, so it may not behave as expected. Currently on Windows symlinks are not supported
 >
-> Up to the current version (0.6.2) zip/tar and unzip/untar should handle files, directories and symlinks. Though, symlink support is still experimental, so it may not behave as expected. Currently on Windows symlinks are not supported
+> Up to the current version (0.7.0) only 32-bit zip are supported, 64-bit zip support is not yet implemented.

--- a/README.md
+++ b/README.md
@@ -396,12 +396,12 @@ This file is meant to be placed in a folder which you plan to zip/tar. It is mea
 > Up to the current version (0.7.0) the .zipignore builds on top of already existing .gitignore rules, so if you only want to ignore some additional files you **do not need** to copy paste the content of the .gitignore.
 
 > [!NOTE]
-> Since version (0.7.0) the strategy of ignoring `*` and the unignore some paths (e.g. `!test`, `!src`, ...) is supported and behaves like in the gitignore specs. Quoting from [gitignore spces](https://git-scm.com/docs/gitignore): *"It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined. "*.
+> Since version (0.7.0) the strategy of ignoring everythin (`*`) and then un-ignoring (!) some paths (e.g. `!test`, `!src`, ...) is supported and behaves like in the gitignore specs. Quoting from [gitignore specs](https://git-scm.com/docs/gitignore): *"It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined. "*.
 >
 > For the same performance reasons and to match git behavior, node-zip-cli doesn’t list excluded directories
 
 > [!WARNING]
-> *Current limitaionts*  
+> *Current limitations*  
 > Up to the current version (0.7.0) zip/tar and unzip/untar should handle files, directories and symlinks. Though, symlink support is still experimental, so it may not behave as expected. Currently on Windows symlinks are not supported
 >
 > Up to the current version (0.7.0) only 32-bit zip are supported, 64-bit zip support is not yet implemented.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-zip-cli",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-zip-cli",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@rollup/plugin-replace": "^5.0.7",
         "@rollup/plugin-run": "^3.1.0",
         "@rollup/plugin-typescript": "^11.1.6",
-        "@types/node": "^18.19.39",
+        "@types/node": "^18.19.40",
         "@types/parse-gitignore": "^1.0.2",
         "@types/tar-stream": "^3.1.3",
         "c8": "^10.1.2",
@@ -1140,9 +1140,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-      "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "version": "18.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.40.tgz",
+      "integrity": "sha512-MIxieZHrm4Ee8XArBIc+Or9HINt2StOmCbgRcXGSJl8q14svRvkZPe7LJq9HKtTI1SK3wU8b91TjntUm7T69Pg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3734,9 +3734,9 @@
       }
     },
     "@types/node": {
-      "version": "18.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-      "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "version": "18.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.40.tgz",
+      "integrity": "sha512-MIxieZHrm4Ee8XArBIc+Or9HINt2StOmCbgRcXGSJl8q14svRvkZPe7LJq9HKtTI1SK3wU8b91TjntUm7T69Pg==",
       "requires": {
         "undici-types": "~5.26.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",
-        "@inquirer/confirm": "^3.1.14",
+        "@inquirer/confirm": "^3.1.15",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "figures": "^6.1.0",
@@ -602,26 +602,26 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.14.tgz",
-      "integrity": "sha512-nbLSX37b2dGPtKWL3rPuR/5hOuD30S+pqJ/MuFiUEgN6GiMs8UMxiurKAMDzKt6C95ltjupa8zH6+3csXNHWpA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.15.tgz",
+      "integrity": "sha512-CiLGi3JmKGEsia5kYJN62yG/njHydbYIkzSBril7tCaKbsnIqxa2h/QiON9NjfwiKck/2siosz4h7lVhLFocMQ==",
       "dependencies": {
-        "@inquirer/core": "^9.0.2",
-        "@inquirer/type": "^1.4.0"
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.2.tgz",
-      "integrity": "sha512-nguvH3TZar3ACwbytZrraRTzGqyxJfYJwv+ZwqZNatAosdWQMP1GV8zvmkNlBe2JeZSaw0WYBHZk52pDpWC9qA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.3.tgz",
+      "integrity": "sha512-p2BRZv/vMmpwlU4ZR966vKQzGVCi4VhLjVofwnFLziTQia541T7i1Ar8/LPh+LzjkXzocme+g5Io6MRtzlCcNA==",
       "dependencies": {
-        "@inquirer/figures": "^1.0.3",
-        "@inquirer/type": "^1.4.0",
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
         "@types/mute-stream": "^0.0.4",
-        "@types/node": "^20.14.9",
+        "@types/node": "^20.14.11",
         "@types/wrap-ansi": "^3.0.0",
         "ansi-escapes": "^4.3.2",
         "cli-spinners": "^2.9.2",
@@ -637,9 +637,9 @@
       }
     },
     "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -675,17 +675,17 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.3.tgz",
-      "integrity": "sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.4.tgz",
+      "integrity": "sha512-R7Gsg6elpuqdn55fBH2y9oYzrU/yKrSmIsDX4ROT51vohrECFzTf2zw9BfUbOW8xjfmM2QbVoVYdTwhrtEKWSQ==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.4.0.tgz",
-      "integrity": "sha512-AjOqykVyjdJQvtfkNDGUyMYGF8xN50VUxftCQWsOyIo4DFRLr6VQhW0VItGI1JIyQGCGgIpKa7hMMwNhZb4OIw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.0.tgz",
+      "integrity": "sha512-L/UdayX9Z1lLN+itoTKqJ/X4DX5DaWu2Sruwt4XgZzMNv32x4qllbzMX4MbJlz0yxAQtU19UvABGOjmdq1u3qA==",
       "dependencies": {
         "mute-stream": "^1.0.0"
       },
@@ -3400,23 +3400,23 @@
       "optional": true
     },
     "@inquirer/confirm": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.14.tgz",
-      "integrity": "sha512-nbLSX37b2dGPtKWL3rPuR/5hOuD30S+pqJ/MuFiUEgN6GiMs8UMxiurKAMDzKt6C95ltjupa8zH6+3csXNHWpA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.15.tgz",
+      "integrity": "sha512-CiLGi3JmKGEsia5kYJN62yG/njHydbYIkzSBril7tCaKbsnIqxa2h/QiON9NjfwiKck/2siosz4h7lVhLFocMQ==",
       "requires": {
-        "@inquirer/core": "^9.0.2",
-        "@inquirer/type": "^1.4.0"
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
       }
     },
     "@inquirer/core": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.2.tgz",
-      "integrity": "sha512-nguvH3TZar3ACwbytZrraRTzGqyxJfYJwv+ZwqZNatAosdWQMP1GV8zvmkNlBe2JeZSaw0WYBHZk52pDpWC9qA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.3.tgz",
+      "integrity": "sha512-p2BRZv/vMmpwlU4ZR966vKQzGVCi4VhLjVofwnFLziTQia541T7i1Ar8/LPh+LzjkXzocme+g5Io6MRtzlCcNA==",
       "requires": {
-        "@inquirer/figures": "^1.0.3",
-        "@inquirer/type": "^1.4.0",
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
         "@types/mute-stream": "^0.0.4",
-        "@types/node": "^20.14.9",
+        "@types/node": "^20.14.11",
         "@types/wrap-ansi": "^3.0.0",
         "ansi-escapes": "^4.3.2",
         "cli-spinners": "^2.9.2",
@@ -3429,9 +3429,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "20.14.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-          "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+          "version": "20.14.11",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+          "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
           "requires": {
             "undici-types": "~5.26.4"
           }
@@ -3457,14 +3457,14 @@
       }
     },
     "@inquirer/figures": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.3.tgz",
-      "integrity": "sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.4.tgz",
+      "integrity": "sha512-R7Gsg6elpuqdn55fBH2y9oYzrU/yKrSmIsDX4ROT51vohrECFzTf2zw9BfUbOW8xjfmM2QbVoVYdTwhrtEKWSQ=="
     },
     "@inquirer/type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.4.0.tgz",
-      "integrity": "sha512-AjOqykVyjdJQvtfkNDGUyMYGF8xN50VUxftCQWsOyIo4DFRLr6VQhW0VItGI1JIyQGCGgIpKa7hMMwNhZb4OIw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.0.tgz",
+      "integrity": "sha512-L/UdayX9Z1lLN+itoTKqJ/X4DX5DaWu2Sruwt4XgZzMNv32x4qllbzMX4MbJlz0yxAQtU19UvABGOjmdq1u3qA==",
       "requires": {
         "mute-stream": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-zip-cli",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Simple nodejs cli which allows you to create and extract zip/tar files with support for .gitignore files",
   "main": "dist/index.mjs",
   "bin": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@commander-js/extra-typings": "^12.1.0",
-    "@inquirer/confirm": "^3.1.14",
+    "@inquirer/confirm": "^3.1.15",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "figures": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@rollup/plugin-replace": "^5.0.7",
     "@rollup/plugin-run": "^3.1.0",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@types/node": "^18.19.39",
+    "@types/node": "^18.19.40",
     "@types/parse-gitignore": "^1.0.2",
     "@types/tar-stream": "^3.1.3",
     "c8": "^10.1.2",

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -1,0 +1,51 @@
+import { readFile } from 'node:fs/promises';
+import { relative } from 'node:path';
+import type { IgnoreFilter } from '@/types/ignore';
+import { boolean_filter } from '@/utils/filter';
+import { read_access } from '@/utils/fs';
+import ignore from 'ignore';
+
+export const load_ignore_rules = async (path: string) => {
+  if (await read_access(path)) {
+    const gitignore_content = `${await readFile(path, {
+      encoding: 'utf-8',
+    })}\n`;
+    return gitignore_content.split('\n').filter(boolean_filter);
+  }
+
+  return [] as string[];
+};
+
+export const create_ignore_filter = (
+  path: string,
+  rules: string[]
+): IgnoreFilter => {
+  const filter = ignore({
+    ignoreCase: false,
+  });
+  filter.add(rules);
+
+  return {
+    path,
+    filter,
+  };
+};
+
+export const is_ignored = (
+  path: string,
+  ignore_filters: IgnoreFilter[]
+): boolean => {
+  let ignored = false;
+
+  for (let i = ignore_filters.length - 1; i >= 0; i--) {
+    const relative_path = relative(ignore_filters[i].path, path);
+    if (!relative_path) continue;
+
+    const test = ignore_filters[i].filter.test(relative_path);
+    ignored = (ignored || test.ignored) && !test.unignored;
+    if (test.unignored) break;
+    if (ignored) break;
+  }
+
+  return ignored;
+};

--- a/src/types/ignore.ts
+++ b/src/types/ignore.ts
@@ -1,0 +1,6 @@
+import type { Ignore } from 'ignore';
+
+export type IgnoreFilter = {
+  path: string;
+  filter: Ignore;
+};

--- a/test/_ignore_/ignore-rules
+++ b/test/_ignore_/ignore-rules
@@ -1,0 +1,12 @@
+# Comment
+src
+*.ts
+**/*.js
+
+# Comment 2
+log.*
+
+# Comment multiline
+# Comment multiline 2
+dist/
+test/**/*

--- a/test/core/ignore.test.ts
+++ b/test/core/ignore.test.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert';
+import { join, relative } from 'node:path';
+import { describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  create_ignore_filter,
+  is_ignored,
+  load_ignore_rules,
+} from '@/core/ignore';
+
+const ignore_dir = join(process.cwd(), 'test', '_ignore_');
+
+const filename = relative(
+  join(process.cwd(), 'test'),
+  fileURLToPath(import.meta.url)
+).replace('.test', '');
+
+describe(filename, async () => {
+  describe('load_ignore_rules', async () => {
+    test('existing file: ignore-rules', async () => {
+      const rules = await load_ignore_rules(join(ignore_dir, 'ignore-rules'));
+      assert.deepStrictEqual(rules, [
+        '# Comment',
+        'src',
+        '*.ts',
+        '**/*.js',
+        '# Comment 2',
+        'log.*',
+        '# Comment multiline',
+        '# Comment multiline 2',
+        'dist/',
+        'test/**/*',
+      ]);
+    });
+    test('non-existing file: nonexisting-ignore-rules', async () => {
+      const rules = await load_ignore_rules(
+        join(ignore_dir, 'non-existing-ignore-rules')
+      );
+      assert.deepStrictEqual(rules, []);
+    });
+  });
+
+  describe('create_ignore_filter', async () => {
+    test('filter', async () => {
+      const ignore_filter = create_ignore_filter('.', [
+        '# Comment',
+        'src',
+        '*.ts',
+        '**/*.js',
+        '# Comment 2',
+        'log.*',
+        '# Comment multiline',
+        '# Comment multiline 2',
+        'dist/',
+        'test/**/*',
+      ]);
+
+      assert.strictEqual(ignore_filter.path, '.');
+      assert.ok(ignore_filter.filter.ignores('src/'));
+      assert.ok(ignore_filter.filter.ignores('index.ts'));
+      assert.ok(ignore_filter.filter.ignores('index.js'));
+      assert.ok(ignore_filter.filter.ignores('log/log.txt'));
+      assert.ok(ignore_filter.filter.ignores('dist/'));
+      assert.ok(ignore_filter.filter.ignores('test/a'));
+    });
+  });
+
+  describe('is_ignored', async () => {
+    test('regular pattern', async () => {
+      const ignore_filters = [
+        create_ignore_filter('.', ['dist', 'coverage', '*.log', '*.zip']),
+      ];
+
+      assert.strictEqual(ignore_filters.length, 1);
+      assert.strictEqual(ignore_filters[0].path, '.');
+
+      assert.ok(is_ignored('out.zip', ignore_filters));
+      assert.ok(is_ignored('dist/index.js', ignore_filters));
+      assert.ok(is_ignored('app.log', ignore_filters));
+      assert.ok(is_ignored('coverage', ignore_filters));
+      assert.ok(is_ignored('coverage/test.html', ignore_filters));
+      assert.ok(!is_ignored('index.ts', ignore_filters));
+      assert.ok(!is_ignored('index.js', ignore_filters));
+      assert.ok(!is_ignored('src', ignore_filters));
+      assert.ok(!is_ignored('.gitignore', ignore_filters));
+      assert.ok(!is_ignored('src/app', ignore_filters));
+      assert.ok(!is_ignored('src/index.ts', ignore_filters));
+      assert.ok(!is_ignored('src/util', ignore_filters));
+      assert.ok(!is_ignored('src/base/index.ts', ignore_filters));
+      assert.ok(!is_ignored('src/.gitignore', ignore_filters));
+
+      ignore_filters.push(create_ignore_filter('test', ['_ignored_']));
+
+      assert.strictEqual(ignore_filters.length, 2);
+      assert.strictEqual(ignore_filters[1].path, 'test');
+
+      assert.ok(is_ignored('test/_ignored_', ignore_filters));
+      assert.ok(is_ignored('test/_ignored_/app', ignore_filters));
+      assert.ok(is_ignored('test/_ignored_/app/test.ts', ignore_filters));
+      assert.ok(is_ignored('test/out.zip', ignore_filters));
+      assert.ok(!is_ignored('test/util', ignore_filters));
+      assert.ok(!is_ignored('test/base/index.ts', ignore_filters));
+      assert.ok(!is_ignored('test/.gitignore', ignore_filters));
+    });
+
+    test('negated pattern', async () => {
+      const ignore_filters = [
+        create_ignore_filter('.', ['*', '!src', 'src/**', '!.gitignore']),
+      ];
+
+      assert.strictEqual(ignore_filters.length, 1);
+      assert.strictEqual(ignore_filters[0].path, '.');
+
+      assert.ok(is_ignored('index.ts', ignore_filters));
+      assert.ok(is_ignored('index.js', ignore_filters));
+      assert.ok(is_ignored('out.zip', ignore_filters));
+      assert.ok(is_ignored('src/index.ts', ignore_filters));
+      assert.ok(!is_ignored('.', ignore_filters));
+      assert.ok(!is_ignored('src', ignore_filters));
+      assert.ok(!is_ignored('.gitignore', ignore_filters));
+
+      ignore_filters.push(
+        create_ignore_filter('src', ['!**/*.ts', '!util', '!.gitignore'])
+      );
+
+      assert.strictEqual(ignore_filters.length, 2);
+      assert.strictEqual(ignore_filters[1].path, 'src');
+
+      assert.ok(is_ignored('src/a', ignore_filters));
+      assert.ok(!is_ignored('src/index.ts', ignore_filters));
+      assert.ok(!is_ignored('src/util', ignore_filters));
+      assert.ok(!is_ignored('src/base/index.ts', ignore_filters));
+      assert.ok(!is_ignored('src/.gitignore', ignore_filters));
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes two issues:
- It adds support for the exclude everithing (*) add something (!) patter, in the same way git does
- It fixes a behavior with `ignore`
  - As per `ignore` documentation, paths to be checked need to be realtive to the directory where the ignore rules are located. With this PR this is now fixed