### PR TITLE
fix: directory should always have trailing separator when passed to ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Setup NodeJS 18.20.3
+      - name: Setup NodeJS version (from .nvmrc)
         uses: actions/setup-node@v4
         with:
-          node-version: 18.20.3
+          node-version-file: .nvmrc
       
       - name: Install dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Simple nodejs cli which allows you to create and extract zip/tar files with supp
 Install it locally with
 
 ```bash
-npm i https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.0/node-zip-cli-0.7.0.tgz
+npm i https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.1/node-zip-cli-0.7.1.tgz
 ```
 
 Or install it globally with
 
 ```bash
-npm i --location=global https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.0/node-zip-cli-0.7.0.tgz
+npm i --location=global https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.1/node-zip-cli-0.7.1.tgz
 ```
 
 ### Other version
@@ -204,7 +204,7 @@ Allows you to specify paths that you want to exclude. This option follows the sa
 > For example, providing `*.mjs` will result in the shell replacing it will all the file matching the wildcard, so as the input to the cli, instead of `"*.mjs"` will be provided the whole list (e.g. "rollup.config.mjs", "test.runner.mjs", ...). Instead, providing `"*.mjs"` will behave as expected, providing as input to the cli the pattern `"*.mjs"`
 
 > [!NOTE]
-> Up to the current version (0.7.0) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
+> Up to the current version (0.7.1) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
 
 ###### `--allow-git`
 
@@ -338,7 +338,7 @@ Allows you to specify paths that you want to exclude. This option follows the sa
 > For example, providing `*.mjs` will result in the shell replacing it will all the file matching the wildcard, so as the input to the cli, instead of `"*.mjs"` will be provided the whole list (e.g. "rollup.config.mjs", "test.runner.mjs", ...). Instead, providing `"*.mjs"` will behave as expected, providing as input to the cli the pattern `"*.mjs"`
 
 > [!NOTE]
-> Up to the current version (0.7.0) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
+> Up to the current version (0.7.1) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
 
 ###### `--allow-git`
 
@@ -393,7 +393,7 @@ Simply run this CLI providing to each command all the necessary options.
 This file is meant to be placed in a folder which you plan to zip/tar. It is meant to be used instead of the .gitignore, if the content of the folder is not related to git, or as an extension of the .gitignore, where you can specify additional rules related only to the zip file creation. The .zipignore file follow the same syntax and rules of the traditional .gitignore
 
 > [!NOTE]
-> Up to the current version (0.7.0) the .zipignore builds on top of already existing .gitignore rules, so if you only want to ignore some additional files you **do not need** to copy paste the content of the .gitignore.
+> Up to the current version (0.7.1) the .zipignore builds on top of already existing .gitignore rules, so if you only want to ignore some additional files you **do not need** to copy paste the content of the .gitignore.
 
 > [!NOTE]
 > Since version (0.7.0) the strategy of ignoring everythin (`*`) and then un-ignoring (!) some paths (e.g. `!test`, `!src`, ...) is supported and behaves like in the gitignore specs. Quoting from [gitignore specs](https://git-scm.com/docs/gitignore): *"It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined. "*.
@@ -402,6 +402,6 @@ This file is meant to be placed in a folder which you plan to zip/tar. It is mea
 
 > [!WARNING]
 > *Current limitations*  
-> Up to the current version (0.7.0) zip/tar and unzip/untar should handle files, directories and symlinks. Though, symlink support is still experimental, so it may not behave as expected. Currently on Windows symlinks are not supported
+> Up to the current version (0.7.1) zip/tar and unzip/untar should handle files, directories and symlinks. Though, symlink support is still experimental, so it may not behave as expected. Currently on Windows symlinks are not supported
 >
-> Up to the current version (0.7.0) only 32-bit zip are supported, 64-bit zip support is not yet implemented.
+> Up to the current version (0.7.1) only 32-bit zip are supported, 64-bit zip support is not yet implemented.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-zip-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-zip-cli",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-zip-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Simple nodejs cli which allows you to create and extract zip/tar files with support for .gitignore files",
   "main": "dist/index.mjs",
   "bin": "dist/index.mjs",

--- a/src/commands/tar.ts
+++ b/src/commands/tar.ts
@@ -52,7 +52,7 @@ const tarCommand = createCommand(name, description)
         }
         return parsedValue;
       })
-      .default(false)
+      .default<false>(false)
       .preset(preset_compression_level)
   )
   .option(
@@ -93,6 +93,7 @@ const tarCommand = createCommand(name, description)
 tarCommand.action(async (options) => {
   const output =
     options.output ?? (options.gzip === false ? 'out.tar' : 'out.tgz');
+
   await exit_fail_on_error(async () => {
     const unique_inputs = unique_entries(normalize_entries(options.input));
 

--- a/src/commands/zip.ts
+++ b/src/commands/zip.ts
@@ -52,7 +52,7 @@ const zipCommand = createCommand(name, description)
         }
         return parsedValue;
       })
-      .default(false)
+      .default<false>(false)
       .preset(preset_compression_level)
   )
   .option(

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -44,7 +44,7 @@ export const is_ignored = (
     if (!relative_path) continue;
 
     // Needed to make sure we properly handle directories
-    relative_path = ensure_trailing_separator(path, is_dir);
+    relative_path = ensure_trailing_separator(relative_path, is_dir);
 
     const test = ignore_filters[i].filter.test(relative_path);
     ignored = (ignored || test.ignored) && !test.unignored;

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -4,6 +4,7 @@ import type { IgnoreFilter } from '@/types/ignore';
 import { boolean_filter } from '@/utils/filter';
 import { read_access } from '@/utils/fs';
 import ignore from 'ignore';
+import { ensure_trailing_separator } from '@/utils/path';
 
 export const load_ignore_rules = async (path: string) => {
   if (await read_access(path)) {
@@ -33,13 +34,17 @@ export const create_ignore_filter = (
 
 export const is_ignored = (
   path: string,
+  is_dir: boolean,
   ignore_filters: IgnoreFilter[]
 ): boolean => {
   let ignored = false;
 
   for (let i = ignore_filters.length - 1; i >= 0; i--) {
-    const relative_path = relative(ignore_filters[i].path, path);
+    let relative_path = relative(ignore_filters[i].path, path);
     if (!relative_path) continue;
+
+    // Needed to make sure we properly handle directories
+    relative_path = ensure_trailing_separator(path, is_dir);
 
     const test = ignore_filters[i].filter.test(relative_path);
     ignored = (ignored || test.ignored) && !test.unignored;

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises';
-import { EOL } from 'node:os';
 import { relative } from 'node:path';
 import type { IgnoreFilter } from '@/types/ignore';
 import { boolean_filter } from '@/utils/filter';
@@ -13,7 +12,7 @@ export const load_ignore_rules = async (path: string) => {
       encoding: 'utf-8',
     })}\n`;
     return gitignore_content
-      .split(EOL)
+      .split(/\r?\n/)
       .map((el) => el.trim())
       .filter(boolean_filter);
   }

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -44,7 +44,7 @@ export const is_ignored = (
     if (!relative_path) continue;
 
     // Needed to make sure we properly handle directories
-    relative_path = ensure_trailing_separator(relative_path, is_dir);
+    if (is_dir) relative_path = ensure_trailing_separator(relative_path);
 
     const test = ignore_filters[i].filter.test(relative_path);
     ignored = (ignored || test.ignored) && !test.unignored;

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -3,8 +3,8 @@ import { relative } from 'node:path';
 import type { IgnoreFilter } from '@/types/ignore';
 import { boolean_filter } from '@/utils/filter';
 import { read_access } from '@/utils/fs';
-import ignore from 'ignore';
 import { ensure_trailing_separator } from '@/utils/path';
+import ignore from 'ignore';
 
 export const load_ignore_rules = async (path: string) => {
   if (await read_access(path)) {

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { EOL } from 'node:os';
 import { relative } from 'node:path';
 import type { IgnoreFilter } from '@/types/ignore';
 import { boolean_filter } from '@/utils/filter';
@@ -11,7 +12,7 @@ export const load_ignore_rules = async (path: string) => {
     const gitignore_content = `${await readFile(path, {
       encoding: 'utf-8',
     })}\n`;
-    return gitignore_content.split('\n').filter(boolean_filter);
+    return gitignore_content.split(EOL).filter(boolean_filter);
   }
 
   return [] as string[];

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -12,7 +12,10 @@ export const load_ignore_rules = async (path: string) => {
     const gitignore_content = `${await readFile(path, {
       encoding: 'utf-8',
     })}\n`;
-    return gitignore_content.split(EOL).filter(boolean_filter);
+    return gitignore_content
+      .split(EOL)
+      .map((el) => el.trim())
+      .filter(boolean_filter);
   }
 
   return [] as string[];

--- a/src/core/tar.ts
+++ b/src/core/tar.ts
@@ -21,6 +21,7 @@ import { spinner_wrapper } from '@/utils/spinner-wrapper';
 import { get_full_mode } from '@/utils/tar';
 import chalk from 'chalk';
 import { extract, pack } from 'tar-stream';
+import { preset_compression_level } from './constants';
 
 export const create_tar = async (
   output_path: string,
@@ -109,7 +110,7 @@ export const create_tar = async (
         },
         gzip !== false
           ? createGzip({
-              level: gzip === true ? undefined : gzip,
+              level: gzip === true ? preset_compression_level : gzip,
             })
           : undefined,
         createWriteStream(output_path),

--- a/src/core/walk.ts
+++ b/src/core/walk.ts
@@ -100,7 +100,8 @@ export const walk = async (
   let n_children = 0;
 
   if (
-    (path_name !== '' && is_ignored(path_name, ignore_filters)) ||
+    (path_name !== '' &&
+      is_ignored(path_name, stats.isDirectory(), ignore_filters)) ||
     !(await read_access(path))
   ) {
     return {

--- a/src/core/zip.ts
+++ b/src/core/zip.ts
@@ -21,6 +21,7 @@ import { is_symlink } from '@/utils/zip';
 import chalk from 'chalk';
 import JSZip from 'jszip';
 import isValidFilename from 'valid-filename';
+import { preset_compression_level } from './constants';
 
 export const create_zip = async (
   output_path: string,
@@ -103,7 +104,7 @@ export const create_zip = async (
             streamFiles: true,
             compression: deflate === false ? 'STORE' : 'DEFLATE',
             compressionOptions: {
-              level: deflate === true ? 6 : +deflate,
+              level: deflate === true ? preset_compression_level : +deflate,
             },
             platform: 'UNIX',
           },

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -13,6 +13,6 @@ export const normalize_entries = (paths: string[]) => {
   return paths.map((el) => normalize(el));
 };
 
-export const ensure_trailing_separator = (path: string, is_dir: boolean) => {
-  return is_dir && !path.endsWith(sep) ? `${path}${sep}` : path;
+export const ensure_trailing_separator = (path: string) => {
+  return path.endsWith(sep) ? path : `${path}${sep}`;
 };

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,4 +1,4 @@
-import { join, normalize } from 'node:path';
+import { join, normalize, sep } from 'node:path';
 
 export const clean_base_dir = (path: string) => {
   const base_dir = join(path, '..');
@@ -11,4 +11,8 @@ export const clean_base_dir = (path: string) => {
 
 export const normalize_entries = (paths: string[]) => {
   return paths.map((el) => normalize(el));
+};
+
+export const ensure_trailing_separator = (path: string, is_dir: boolean) => {
+  return is_dir && !path.endsWith(sep) ? `${path}${sep}` : path;
 };

--- a/test.runner.mjs
+++ b/test.runner.mjs
@@ -35,5 +35,8 @@ const files =
         .map((el) => join(dir, el));
 
 run({ files, concurrency: parallel, only })
+  .on('test:fail', () => {
+    process.exitCode = 1;
+  })
   .compose(process.stdout.isTTY ? new spec() : tap)
   .pipe(process.stdout);

--- a/test/core/ignore.test.ts
+++ b/test/core/ignore.test.ts
@@ -74,33 +74,35 @@ describe(filename, async () => {
       assert.strictEqual(ignore_filters.length, 1);
       assert.strictEqual(ignore_filters[0].path, '.');
 
-      assert.ok(is_ignored('out.zip', ignore_filters));
-      assert.ok(is_ignored('dist/index.js', ignore_filters));
-      assert.ok(is_ignored('app.log', ignore_filters));
-      assert.ok(is_ignored('coverage', ignore_filters));
-      assert.ok(is_ignored('coverage/test.html', ignore_filters));
-      assert.ok(!is_ignored('index.ts', ignore_filters));
-      assert.ok(!is_ignored('index.js', ignore_filters));
-      assert.ok(!is_ignored('src', ignore_filters));
-      assert.ok(!is_ignored('.gitignore', ignore_filters));
-      assert.ok(!is_ignored('src/app', ignore_filters));
-      assert.ok(!is_ignored('src/index.ts', ignore_filters));
-      assert.ok(!is_ignored('src/util', ignore_filters));
-      assert.ok(!is_ignored('src/base/index.ts', ignore_filters));
-      assert.ok(!is_ignored('src/.gitignore', ignore_filters));
+      assert.ok(is_ignored('out.zip', false, ignore_filters));
+      assert.ok(is_ignored('dist/index.js', false, ignore_filters));
+      assert.ok(is_ignored('app.log', false, ignore_filters));
+      assert.ok(is_ignored('coverage', true, ignore_filters));
+      assert.ok(is_ignored('coverage/test.html', false, ignore_filters));
+      assert.ok(!is_ignored('index.ts', false, ignore_filters));
+      assert.ok(!is_ignored('index.js', false, ignore_filters));
+      assert.ok(!is_ignored('src', true, ignore_filters));
+      assert.ok(!is_ignored('.gitignore', false, ignore_filters));
+      assert.ok(!is_ignored('src/app', true, ignore_filters));
+      assert.ok(!is_ignored('src/index.ts', false, ignore_filters));
+      assert.ok(!is_ignored('src/util', true, ignore_filters));
+      assert.ok(!is_ignored('src/base/index.ts', false, ignore_filters));
+      assert.ok(!is_ignored('src/.gitignore', false, ignore_filters));
 
       ignore_filters.push(create_ignore_filter('test', ['_ignored_']));
 
       assert.strictEqual(ignore_filters.length, 2);
       assert.strictEqual(ignore_filters[1].path, 'test');
 
-      assert.ok(is_ignored('test/_ignored_', ignore_filters));
-      assert.ok(is_ignored('test/_ignored_/app', ignore_filters));
-      assert.ok(is_ignored('test/_ignored_/app/test.ts', ignore_filters));
-      assert.ok(is_ignored('test/out.zip', ignore_filters));
-      assert.ok(!is_ignored('test/util', ignore_filters));
-      assert.ok(!is_ignored('test/base/index.ts', ignore_filters));
-      assert.ok(!is_ignored('test/.gitignore', ignore_filters));
+      assert.ok(is_ignored('test/_ignored_', true, ignore_filters));
+      assert.ok(is_ignored('test/_ignored_/app', true, ignore_filters));
+      assert.ok(
+        is_ignored('test/_ignored_/app/test.ts', false, ignore_filters)
+      );
+      assert.ok(is_ignored('test/out.zip', false, ignore_filters));
+      assert.ok(!is_ignored('test/util', true, ignore_filters));
+      assert.ok(!is_ignored('test/base/index.ts', false, ignore_filters));
+      assert.ok(!is_ignored('test/.gitignore', false, ignore_filters));
     });
 
     test('negated pattern', async () => {
@@ -111,13 +113,13 @@ describe(filename, async () => {
       assert.strictEqual(ignore_filters.length, 1);
       assert.strictEqual(ignore_filters[0].path, '.');
 
-      assert.ok(is_ignored('index.ts', ignore_filters));
-      assert.ok(is_ignored('index.js', ignore_filters));
-      assert.ok(is_ignored('out.zip', ignore_filters));
-      assert.ok(is_ignored('src/index.ts', ignore_filters));
-      assert.ok(!is_ignored('.', ignore_filters));
-      assert.ok(!is_ignored('src', ignore_filters));
-      assert.ok(!is_ignored('.gitignore', ignore_filters));
+      assert.ok(is_ignored('index.ts', false, ignore_filters));
+      assert.ok(is_ignored('index.js', false, ignore_filters));
+      assert.ok(is_ignored('out.zip', false, ignore_filters));
+      assert.ok(is_ignored('src/index.ts', false, ignore_filters));
+      assert.ok(!is_ignored('.', true, ignore_filters));
+      assert.ok(!is_ignored('src', true, ignore_filters));
+      assert.ok(!is_ignored('.gitignore', false, ignore_filters));
 
       ignore_filters.push(
         create_ignore_filter('src', ['!**/*.ts', '!util', '!.gitignore'])
@@ -126,11 +128,23 @@ describe(filename, async () => {
       assert.strictEqual(ignore_filters.length, 2);
       assert.strictEqual(ignore_filters[1].path, 'src');
 
-      assert.ok(is_ignored('src/a', ignore_filters));
-      assert.ok(!is_ignored('src/index.ts', ignore_filters));
-      assert.ok(!is_ignored('src/util', ignore_filters));
-      assert.ok(!is_ignored('src/base/index.ts', ignore_filters));
-      assert.ok(!is_ignored('src/.gitignore', ignore_filters));
+      assert.ok(is_ignored('src/a', true, ignore_filters));
+      assert.ok(!is_ignored('src/index.ts', false, ignore_filters));
+      assert.ok(!is_ignored('src/util', true, ignore_filters));
+      assert.ok(!is_ignored('src/base/index.ts', false, ignore_filters));
+      assert.ok(!is_ignored('src/.gitignore', false, ignore_filters));
+    });
+
+    test('directory: no trailing slash in ignore rule', async () => {
+      const ignore_filters = [create_ignore_filter('.', ['*', '!src'])];
+
+      assert.ok(!is_ignored('src', true, ignore_filters));
+    });
+
+    test('directory: trailing slash in ignore rule', async () => {
+      const ignore_filters = [create_ignore_filter('.', ['*', '!src/'])];
+
+      assert.ok(!is_ignored('src', true, ignore_filters));
     });
   });
 });

--- a/test/core/ignore.test.ts
+++ b/test/core/ignore.test.ts
@@ -135,16 +135,28 @@ describe(filename, async () => {
       assert.ok(!is_ignored('src/.gitignore', false, ignore_filters));
     });
 
-    test('directory: no trailing slash in ignore rule', async () => {
+    test('directory: no trailing slash in ignore rule (negated)', async () => {
       const ignore_filters = [create_ignore_filter('.', ['*', '!src'])];
 
       assert.ok(!is_ignored('src', true, ignore_filters));
     });
 
-    test('directory: trailing slash in ignore rule', async () => {
+    test('directory: trailing slash in ignore rule (negated)', async () => {
       const ignore_filters = [create_ignore_filter('.', ['*', '!src/'])];
 
       assert.ok(!is_ignored('src', true, ignore_filters));
+    });
+
+    test('directory: no trailing slash in ignore rule', async () => {
+      const ignore_filters = [create_ignore_filter('.', ['src'])];
+
+      assert.ok(is_ignored('src', true, ignore_filters));
+    });
+
+    test('directory: trailing slash in ignore rule', async () => {
+      const ignore_filters = [create_ignore_filter('.', ['src/'])];
+
+      assert.ok(is_ignored('src', true, ignore_filters));
     });
   });
 });

--- a/test/core/ignore.test.ts
+++ b/test/core/ignore.test.ts
@@ -158,5 +158,29 @@ describe(filename, async () => {
 
       assert.ok(is_ignored('src', true, ignore_filters));
     });
+
+    test('sub directory: no trailing slash in ignore rule (negated)', async () => {
+      const ignore_filters = [create_ignore_filter('root', ['*', '!src'])];
+
+      assert.ok(!is_ignored('root/src', true, ignore_filters));
+    });
+
+    test('sub directory: trailing slash in ignore rule (negated)', async () => {
+      const ignore_filters = [create_ignore_filter('root', ['*', '!src/'])];
+
+      assert.ok(!is_ignored('root/src', true, ignore_filters));
+    });
+
+    test('sub directory: no trailing slash in ignore rule', async () => {
+      const ignore_filters = [create_ignore_filter('root', ['src'])];
+
+      assert.ok(is_ignored('root/src', true, ignore_filters));
+    });
+
+    test('sub directory: trailing slash in ignore rule', async () => {
+      const ignore_filters = [create_ignore_filter('root', ['src/'])];
+
+      assert.ok(is_ignored('root/src', true, ignore_filters));
+    });
   });
 });

--- a/test/core/walk.test.ts
+++ b/test/core/walk.test.ts
@@ -1486,61 +1486,79 @@ describe(filename, async () => {
       }
     );
 
-    test("test/_case-sensitive_: relative {keep_parent: 'none', symlink: 'none'} ignore 'a.txt", async (ctx) => {
-      const input = [join('test', '_case-sensitive_')];
-      const [entries, conflicting_list, map] = await list_entries(
-        input,
-        is_windows,
-        'none',
-        'none',
-        false,
-        ['a.txt']
-      );
+    test(
+      "test/_case-sensitive_: relative {keep_parent: 'none', symlink: 'none'} ignore 'a.txt'",
+      {
+        skip:
+          platform() === 'linux'
+            ? undefined
+            : `${platform()} usually has a case-insensitive file system`,
+      },
+      async (ctx) => {
+        const input = [join('test', '_case-sensitive_')];
+        const [entries, conflicting_list, map] = await list_entries(
+          input,
+          is_windows,
+          'none',
+          'none',
+          false,
+          ['a.txt']
+        );
 
-      assert.strictEqual(entries.length, 1);
-      assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 1);
+        assert.strictEqual(entries.length, 1);
+        assert.strictEqual(conflicting_list.length, 0);
+        assert.strictEqual(map.size, 1);
 
-      assert.strictEqual(entries[0].path, join(input[0], 'A.txt'));
-      assert.strictEqual(entries[0].cleaned_path, 'A.txt');
-      assert.strictEqual(entries[0].type, 'file');
-      const stats_a = await lstat(entries[0].path);
-      assert.deepStrictEqual(entries[0].stats, {
-        uid: stats_a.uid,
-        gid: stats_a.gid,
-        mtime: stats_a.mtime,
-        mode: fix_mode(stats_a.mode, is_windows),
-        size: 1,
-      });
-    });
+        assert.strictEqual(entries[0].path, join(input[0], 'A.txt'));
+        assert.strictEqual(entries[0].cleaned_path, 'A.txt');
+        assert.strictEqual(entries[0].type, 'file');
+        const stats_a = await lstat(entries[0].path);
+        assert.deepStrictEqual(entries[0].stats, {
+          uid: stats_a.uid,
+          gid: stats_a.gid,
+          mtime: stats_a.mtime,
+          mode: fix_mode(stats_a.mode, is_windows),
+          size: 1,
+        });
+      }
+    );
 
-    test("test/_case-sensitive_: relative {keep_parent: 'none', symlink: 'none'} ignore 'A.txt", async (ctx) => {
-      const input = [join('test', '_case-sensitive_')];
-      const [entries, conflicting_list, map] = await list_entries(
-        input,
-        is_windows,
-        'none',
-        'none',
-        false,
-        ['A.txt']
-      );
+    test(
+      "test/_case-sensitive_: relative {keep_parent: 'none', symlink: 'none'} ignore 'A.txt'",
+      {
+        skip:
+          platform() === 'linux'
+            ? undefined
+            : `${platform()} usually has a case-insensitive file system`,
+      },
+      async (ctx) => {
+        const input = [join('test', '_case-sensitive_')];
+        const [entries, conflicting_list, map] = await list_entries(
+          input,
+          is_windows,
+          'none',
+          'none',
+          false,
+          ['A.txt']
+        );
 
-      assert.strictEqual(entries.length, 1);
-      assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 1);
+        assert.strictEqual(entries.length, 1);
+        assert.strictEqual(conflicting_list.length, 0);
+        assert.strictEqual(map.size, 1);
 
-      assert.strictEqual(entries[0].path, join(input[0], 'a.txt'));
-      assert.strictEqual(entries[0].cleaned_path, 'a.txt');
-      assert.strictEqual(entries[0].type, 'file');
-      const stats_a = await lstat(entries[0].path);
-      assert.deepStrictEqual(entries[0].stats, {
-        uid: stats_a.uid,
-        gid: stats_a.gid,
-        mtime: stats_a.mtime,
-        mode: fix_mode(stats_a.mode, is_windows),
-        size: 1,
-      });
-    });
+        assert.strictEqual(entries[0].path, join(input[0], 'a.txt'));
+        assert.strictEqual(entries[0].cleaned_path, 'a.txt');
+        assert.strictEqual(entries[0].type, 'file');
+        const stats_a = await lstat(entries[0].path);
+        assert.deepStrictEqual(entries[0].stats, {
+          uid: stats_a.uid,
+          gid: stats_a.gid,
+          mtime: stats_a.mtime,
+          mode: fix_mode(stats_a.mode, is_windows),
+          size: 1,
+        });
+      }
+    );
   });
 
   describe('list_entries: disable ignore rules', async () => {

--- a/test/core/walk.test.ts
+++ b/test/core/walk.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { lstat, mkdir, rm, writeFile } from 'node:fs/promises';
-import { platform } from 'node:os';
+import { EOL, platform } from 'node:os';
 import { join, relative } from 'node:path';
 import { after, before, describe, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -1575,8 +1575,14 @@ describe(filename, async () => {
       await writeFile(join(list_entries_dir, 'dir-2', 'd.txt'), 'd');
       await writeFile(join(list_entries_dir, 'e.txt'), 'e');
 
-      await writeFile(join(list_entries_dir, '.gitignore'), 'a.txt\nc.txt\n');
-      await writeFile(join(list_entries_dir, '.zipignore'), 'b.txt\nd.txt\n');
+      await writeFile(
+        join(list_entries_dir, '.gitignore'),
+        `a.txt${EOL}c.txt${EOL}`
+      );
+      await writeFile(
+        join(list_entries_dir, '.zipignore'),
+        `b.txt${EOL}d.txt${EOL}`
+      );
     });
 
     after(async () => {

--- a/test/utils/broken-symlink.test.ts
+++ b/test/utils/broken-symlink.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import type { BrokenSymlink } from '@/types/fs';
 import { log_broken_symlink } from '@/utils/broken-symlink';
 import chalk from 'chalk';
-import figureSet from 'figures';
+import { mainSymbols } from 'figures';
 
 const filename = relative(
   join(process.cwd(), 'test'),
@@ -54,7 +54,7 @@ describe(filename, async () => {
       if (process.stderr.isTTY) {
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[0].result,
-          `  ${chalk.yellow(figureSet.warning)} 1 broken symlink\n`
+          `  ${chalk.yellow(mainSymbols.warning)} 1 broken symlink\n`
         );
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[1].result,
@@ -69,7 +69,7 @@ describe(filename, async () => {
       } else {
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[0].result,
-          `${figureSet.warning} 1 broken symlink\n`
+          `${mainSymbols.warning} 1 broken symlink\n`
         );
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[1].result,
@@ -104,7 +104,7 @@ describe(filename, async () => {
       if (process.stderr.isTTY) {
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[0].result,
-          `  ${chalk.yellow(figureSet.warning)} 2 broken symlinks\n`
+          `  ${chalk.yellow(mainSymbols.warning)} 2 broken symlinks\n`
         );
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[1].result,
@@ -125,7 +125,7 @@ describe(filename, async () => {
       } else {
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[0].result,
-          `${figureSet.warning} 2 broken symlinks\n`
+          `${mainSymbols.warning} 2 broken symlinks\n`
         );
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[1].result,

--- a/test/utils/conflicts.test.ts
+++ b/test/utils/conflicts.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import type { ConflictingFsEntry } from '@/types/fs';
 import { log_conflicts } from '@/utils/conflicts';
 import chalk from 'chalk';
-import figureSet from 'figures';
+import { mainSymbols } from 'figures';
 
 const filename = relative(
   join(process.cwd(), 'test'),
@@ -54,7 +54,7 @@ describe(filename, async () => {
       if (process.stderr.isTTY) {
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[0].result,
-          `  ${chalk.yellow(figureSet.warning)} 1 conflicting entry\n`
+          `  ${chalk.yellow(mainSymbols.warning)} 1 conflicting entry\n`
         );
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[1].result,
@@ -69,7 +69,7 @@ describe(filename, async () => {
       } else {
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[0].result,
-          `${figureSet.warning} 1 conflicting entry\n`
+          `${mainSymbols.warning} 1 conflicting entry\n`
         );
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[1].result,
@@ -104,7 +104,7 @@ describe(filename, async () => {
       if (process.stderr.isTTY) {
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[0].result,
-          `  ${chalk.yellow(figureSet.warning)} 2 conflicting entries\n`
+          `  ${chalk.yellow(mainSymbols.warning)} 2 conflicting entries\n`
         );
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[1].result,
@@ -125,7 +125,7 @@ describe(filename, async () => {
       } else {
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[0].result,
-          `${figureSet.warning} 2 conflicting entries\n`
+          `${mainSymbols.warning} 2 conflicting entries\n`
         );
         assert.strictEqual(
           mocked_process_stderr_write.mock.calls[1].result,

--- a/test/utils/path.test.ts
+++ b/test/utils/path.test.ts
@@ -67,22 +67,12 @@ describe(filename, async () => {
   });
 
   describe('ensure_trailing_separator', async () => {
-    test('file', () => {
-      assert.strictEqual(
-        ensure_trailing_separator('index.ts', false),
-        'index.ts'
-      );
+    test('dir: no trailing separator', () => {
+      assert.strictEqual(ensure_trailing_separator('src'), `src${sep}`);
     });
 
     test('dir: no trailing separator', () => {
-      assert.strictEqual(ensure_trailing_separator('src', true), `src${sep}`);
-    });
-
-    test('dir: no trailing separator', () => {
-      assert.strictEqual(
-        ensure_trailing_separator(`src${sep}`, true),
-        `src${sep}`
-      );
+      assert.strictEqual(ensure_trailing_separator(`src${sep}`), `src${sep}`);
     });
   });
 });

--- a/test/utils/path.test.ts
+++ b/test/utils/path.test.ts
@@ -1,9 +1,13 @@
 import assert from 'node:assert';
 import { platform } from 'node:os';
-import { join, relative } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import { before, describe, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { clean_base_dir, normalize_entries } from '@/utils/path';
+import {
+  clean_base_dir,
+  ensure_trailing_separator,
+  normalize_entries,
+} from '@/utils/path';
 import chalk from 'chalk';
 
 const filename = relative(
@@ -60,5 +64,25 @@ describe(filename, async () => {
         );
       }
     );
+  });
+
+  describe('ensure_trailing_separator', async () => {
+    test('file', () => {
+      assert.strictEqual(
+        ensure_trailing_separator('index.ts', false),
+        'index.ts'
+      );
+    });
+
+    test('dir: no trailing separator', () => {
+      assert.strictEqual(ensure_trailing_separator('src', true), `src${sep}`);
+    });
+
+    test('dir: no trailing separator', () => {
+      assert.strictEqual(
+        ensure_trailing_separator(`src${sep}`, true),
+        `src${sep}`
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR fixes and issue with the way directory were passed to `ignore`
Previously, if a directory (e.g., `src`) was passed to `ignore` to check if ignored or not, the behavior differed if the rule inside it was `src` or `src/`. This PR addresses that, ensuring that both `src` and `src/` will ignore the directory `src`

Other minor fixes
- ensure test environment set exit code to 1 if at least one test fails
  - previously test environment was silently failing
- fix some issues with tests on windows
- exclude case sensitive tests on windows and macos as the filesystem on those operating systems is case insensitive by default