### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Simple nodejs cli which allows you to create and extract zip/tar files with supp
 Install it locally with
 
 ```bash
-npm i https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.1/node-zip-cli-0.7.1.tgz
+npm i https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.2/node-zip-cli-0.7.2.tgz
 ```
 
 Or install it globally with
 
 ```bash
-npm i --location=global https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.1/node-zip-cli-0.7.1.tgz
+npm i --location=global https://github.com/matteosacchetto/node-zip-cli/releases/download/v0.7.2/node-zip-cli-0.7.2.tgz
 ```
 
 ### Other version
@@ -204,7 +204,7 @@ Allows you to specify paths that you want to exclude. This option follows the sa
 > For example, providing `*.mjs` will result in the shell replacing it will all the file matching the wildcard, so as the input to the cli, instead of `"*.mjs"` will be provided the whole list (e.g. "rollup.config.mjs", "test.runner.mjs", ...). Instead, providing `"*.mjs"` will behave as expected, providing as input to the cli the pattern `"*.mjs"`
 
 > [!NOTE]
-> Up to the current version (0.7.1) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
+> Up to the current version (0.7.2) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
 
 ###### `--allow-git`
 
@@ -338,7 +338,7 @@ Allows you to specify paths that you want to exclude. This option follows the sa
 > For example, providing `*.mjs` will result in the shell replacing it will all the file matching the wildcard, so as the input to the cli, instead of `"*.mjs"` will be provided the whole list (e.g. "rollup.config.mjs", "test.runner.mjs", ...). Instead, providing `"*.mjs"` will behave as expected, providing as input to the cli the pattern `"*.mjs"`
 
 > [!NOTE]
-> Up to the current version (0.7.1) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
+> Up to the current version (0.7.2) the list of paths to ignore which are specified with this options are applied after default ignore paths (like `.git`) BUT before any .gitignore or .zipignore file. This means that paths you specify here could be overridden by the aforementioned files.
 
 ###### `--allow-git`
 
@@ -393,7 +393,7 @@ Simply run this CLI providing to each command all the necessary options.
 This file is meant to be placed in a folder which you plan to zip/tar. It is meant to be used instead of the .gitignore, if the content of the folder is not related to git, or as an extension of the .gitignore, where you can specify additional rules related only to the zip file creation. The .zipignore file follow the same syntax and rules of the traditional .gitignore
 
 > [!NOTE]
-> Up to the current version (0.7.1) the .zipignore builds on top of already existing .gitignore rules, so if you only want to ignore some additional files you **do not need** to copy paste the content of the .gitignore.
+> Up to the current version (0.7.2) the .zipignore builds on top of already existing .gitignore rules, so if you only want to ignore some additional files you **do not need** to copy paste the content of the .gitignore.
 
 > [!NOTE]
 > Since version (0.7.0) the strategy of ignoring everythin (`*`) and then un-ignoring (!) some paths (e.g. `!test`, `!src`, ...) is supported and behaves like in the gitignore specs. Quoting from [gitignore specs](https://git-scm.com/docs/gitignore): *"It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined. "*.
@@ -402,6 +402,6 @@ This file is meant to be placed in a folder which you plan to zip/tar. It is mea
 
 > [!WARNING]
 > *Current limitations*  
-> Up to the current version (0.7.1) zip/tar and unzip/untar should handle files, directories and symlinks. Though, symlink support is still experimental, so it may not behave as expected. Currently on Windows symlinks are not supported
+> Up to the current version (0.7.2) zip/tar and unzip/untar should handle files, directories and symlinks. Though, symlink support is still experimental, so it may not behave as expected. Currently on Windows symlinks are not supported
 >
-> Up to the current version (0.7.1) only 32-bit zip are supported, 64-bit zip support is not yet implemented.
+> Up to the current version (0.7.2) only 32-bit zip are supported, 64-bit zip support is not yet implemented.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-zip-cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-zip-cli",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-zip-cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Simple nodejs cli which allows you to create and extract zip/tar files with support for .gitignore files",
   "main": "dist/index.mjs",
   "bin": "dist/index.mjs",


### PR DESCRIPTION
This PR bumps the `node-zip-cli` version to 0.7.2, to prepeare it for release