### PR TITLE
fix: ensure retrieval of the correct mode for parent directories

### DIFF
--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -119,12 +119,14 @@ export const map_absolute_path_to_clean_entry_with_mode = (
     for (let i = 0; i < entry.cleaned_path.split(sep).length - 1; i++) {
       parent = dirname(parent);
       cleaned_parent = dirname(cleaned_parent);
-      if (!absolute_path_to_clean_entry_with_mode.has(parent)) {
-        absolute_path_to_clean_entry_with_mode.set(parent, {
-          cleaned_path: cleaned_parent,
-          mode: get_default_mode('directory'),
-        });
-      }
+
+      // No need to iterate over all the parents once a parent is found
+      if (absolute_path_to_clean_entry_with_mode.has(parent)) break;
+
+      absolute_path_to_clean_entry_with_mode.set(parent, {
+        cleaned_path: cleaned_parent,
+        mode: get_default_mode('directory'),
+      });
     }
   }
 

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -113,6 +113,19 @@ export const map_absolute_path_to_clean_entry_with_mode = (
       cleaned_path: entry.cleaned_path,
       mode: entry.stats.mode,
     });
+
+    let parent = resolve(entry.path);
+    let cleaned_parent = resolve(entry.cleaned_path);
+    for (let i = 0; i < entry.cleaned_path.split(sep).length - 1; i++) {
+      parent = dirname(parent);
+      cleaned_parent = dirname(cleaned_parent);
+      if (!absolute_path_to_clean_entry_with_mode.has(parent)) {
+        absolute_path_to_clean_entry_with_mode.set(parent, {
+          cleaned_path: cleaned_parent,
+          mode: get_default_mode('directory'),
+        });
+      }
+    }
   }
 
   return absolute_path_to_clean_entry_with_mode;

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -119,14 +119,12 @@ export const map_absolute_path_to_clean_entry_with_mode = (
     for (let i = 0; i < entry.cleaned_path.split(sep).length - 1; i++) {
       parent = dirname(parent);
       cleaned_parent = dirname(cleaned_parent);
-
-      // No need to iterate over all the parents once a parent is found
-      if (absolute_path_to_clean_entry_with_mode.has(parent)) break;
-
-      absolute_path_to_clean_entry_with_mode.set(parent, {
-        cleaned_path: cleaned_parent,
-        mode: get_default_mode('directory'),
-      });
+      if (!absolute_path_to_clean_entry_with_mode.has(parent)) {
+        absolute_path_to_clean_entry_with_mode.set(parent, {
+          cleaned_path: cleaned_parent,
+          mode: get_default_mode('directory'),
+        });
+      }
     }
   }
 

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -173,6 +173,14 @@ export const normalize_windows_path = (path: string, is_windows: boolean) => {
   return path;
 };
 
+export const remove_trailing_sep = (path: string, sep: string) => {
+  if (path.endsWith(sep)) {
+    return path.slice(0, -1);
+  }
+
+  return path;
+};
+
 /**
  * This function is a modified version of the implementation in node-tar
  *
@@ -180,6 +188,7 @@ export const normalize_windows_path = (path: string, is_windows: boolean) => {
  */
 export const clean_path = (path: string) => {
   let final_path = path.split(sep).join('/');
+  final_path = remove_trailing_sep(final_path, '/');
 
   if (isAbsolute(path)) {
     let parsed_path = parse(final_path);

--- a/test/core/tar.test.ts
+++ b/test/core/tar.test.ts
@@ -424,7 +424,7 @@ describe(filename, async () => {
 
       assert.strictEqual(files.length, 3);
       assert.strictEqual(conflicting_files.length, 0);
-      assert.strictEqual(map.size, 3);
+      assert.strictEqual(map.size, 3 + 3);
 
       const output_path = join(create_tar_dir, 'out-6.tar');
       await create_tar(output_path, files, map, 2, false, is_windows);
@@ -492,7 +492,7 @@ describe(filename, async () => {
 
       assert.strictEqual(files.length, 3);
       assert.strictEqual(conflicting_files.length, 0);
-      assert.strictEqual(map.size, 3);
+      assert.strictEqual(map.size, 3 + 3);
 
       const output_path = join(create_tar_dir, 'out-7.tgz');
       await create_tar(output_path, files, map, 2, 9, is_windows);
@@ -560,7 +560,7 @@ describe(filename, async () => {
 
       assert.strictEqual(files.length, 3);
       assert.strictEqual(conflicting_files.length, 0);
-      assert.strictEqual(map.size, 3);
+      assert.strictEqual(map.size, 3 + 3);
 
       const output_path = join(create_tar_dir, 'out-8.tgz');
       await create_tar(output_path, files, map, 2, true, is_windows);

--- a/test/core/walk.test.ts
+++ b/test/core/walk.test.ts
@@ -1142,7 +1142,7 @@ describe(filename, async () => {
 
         assert.strictEqual(entries.length, 5);
         assert.strictEqual(conflicting_list.length, 0);
-        assert.strictEqual(map.size, 5 + 2 + 1); // includes test, test/_data_, test/_data_/dir-1 and test/_data_/dir-2
+        assert.strictEqual(map.size, 5 + 2 + 2); // includes test, test/_data_, test/_data_/dir-1 and test/_data_/dir-2
 
         assert.strictEqual(entries[0].path, input[0]);
         assert.strictEqual(entries[0].cleaned_path, input[0]);

--- a/test/core/walk.test.ts
+++ b/test/core/walk.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { lstat, mkdir, rm, writeFile } from 'node:fs/promises';
 import { EOL, platform } from 'node:os';
-import { join, relative } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import { after, before, describe, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { is_windows } from '@/core/constants';
@@ -32,7 +32,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 3);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 3);
+      assert.strictEqual(map.size, 3 + 2); // we also have test and test/_data_
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, input[0]);
@@ -160,7 +160,10 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 3);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 3);
+      assert.strictEqual(
+        map.size,
+        3 + 2 + (process.cwd().split(sep).length - 1)
+      );
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, clean_path(input[0]));
@@ -297,7 +300,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 6);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 6);
+      assert.strictEqual(map.size, 6 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, input[0]);
@@ -521,7 +524,10 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 6);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 6);
+      assert.strictEqual(
+        map.size,
+        6 + 2 + (process.cwd().split(sep).length - 1)
+      );
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, clean_path(input[0]));
@@ -601,7 +607,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 6);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 6);
+      assert.strictEqual(map.size, 6 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, input[0]);
@@ -813,7 +819,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 7);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 7);
+      assert.strictEqual(map.size, 7 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, input[0]);
@@ -1136,7 +1142,7 @@ describe(filename, async () => {
 
         assert.strictEqual(entries.length, 5);
         assert.strictEqual(conflicting_list.length, 0);
-        assert.strictEqual(map.size, 5);
+        assert.strictEqual(map.size, 5 + 2 + 2); // includes test, test/_data_, test/_data_/dir-1 and test/_data_/dir-2
 
         assert.strictEqual(entries[0].path, input[0]);
         assert.strictEqual(entries[0].cleaned_path, input[0]);
@@ -1227,7 +1233,7 @@ describe(filename, async () => {
 
         assert.strictEqual(entries.length, 3);
         assert.strictEqual(conflicting_list.length, 0);
-        assert.strictEqual(map.size, 3);
+        assert.strictEqual(map.size, 3 + 2);
 
         assert.strictEqual(entries[0].path, input[0]);
         assert.strictEqual(entries[0].cleaned_path, input[0]);
@@ -1283,7 +1289,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 2);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 2);
+      assert.strictEqual(map.size, 2 + 1);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, input[0]);
@@ -1316,7 +1322,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 2);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 2);
+      assert.strictEqual(map.size, 2 + 1);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, input[0]);
@@ -1348,7 +1354,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 1);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 1);
+      assert.strictEqual(map.size, 1 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, input[0]);
@@ -1375,7 +1381,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 1);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 1);
+      assert.strictEqual(map.size, 1 + 1);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].cleaned_path, join('_data_', 'empty'));
@@ -1603,7 +1609,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 4);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 4);
+      assert.strictEqual(map.size, 4 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].type, 'directory');
@@ -1632,7 +1638,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 3);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 3);
+      assert.strictEqual(map.size, 3 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].type, 'directory');
@@ -1658,7 +1664,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 8);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 8);
+      assert.strictEqual(map.size, 8 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].type, 'directory');
@@ -1699,7 +1705,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 8);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 8);
+      assert.strictEqual(map.size, 8 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].type, 'directory');
@@ -1740,7 +1746,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 10);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 10);
+      assert.strictEqual(map.size, 10 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].type, 'directory');
@@ -1787,7 +1793,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 4);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 4);
+      assert.strictEqual(map.size, 4 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].type, 'directory');
@@ -1816,7 +1822,7 @@ describe(filename, async () => {
 
       assert.strictEqual(entries.length, 10);
       assert.strictEqual(conflicting_list.length, 0);
-      assert.strictEqual(map.size, 10);
+      assert.strictEqual(map.size, 10 + 2);
 
       assert.strictEqual(entries[0].path, input[0]);
       assert.strictEqual(entries[0].type, 'directory');

--- a/test/core/walk.test.ts
+++ b/test/core/walk.test.ts
@@ -1142,7 +1142,7 @@ describe(filename, async () => {
 
         assert.strictEqual(entries.length, 5);
         assert.strictEqual(conflicting_list.length, 0);
-        assert.strictEqual(map.size, 5 + 2 + 2); // includes test, test/_data_, test/_data_/dir-1 and test/_data_/dir-2
+        assert.strictEqual(map.size, 5 + 2 + 1); // includes test, test/_data_, test/_data_/dir-1 and test/_data_/dir-2
 
         assert.strictEqual(entries[0].path, input[0]);
         assert.strictEqual(entries[0].cleaned_path, input[0]);

--- a/test/core/zip.test.ts
+++ b/test/core/zip.test.ts
@@ -376,7 +376,7 @@ describe(filename, async () => {
 
       assert.strictEqual(files.length, 3);
       assert.strictEqual(conflicting_files.length, 0);
-      assert.strictEqual(map.size, 3);
+      assert.strictEqual(map.size, 3 + 3);
 
       const output_path = join(create_zip_dir, 'out-6.zip');
       await create_zip(output_path, files, map, 2, false, is_windows);
@@ -471,7 +471,7 @@ describe(filename, async () => {
 
       assert.strictEqual(files.length, 3);
       assert.strictEqual(conflicting_files.length, 0);
-      assert.strictEqual(map.size, 3);
+      assert.strictEqual(map.size, 3 + 3);
 
       const output_path = join(create_zip_dir, 'out-7.zip');
       await create_zip(output_path, files, map, 2, 9, is_windows);
@@ -566,7 +566,7 @@ describe(filename, async () => {
 
       assert.strictEqual(files.length, 3);
       assert.strictEqual(conflicting_files.length, 0);
-      assert.strictEqual(map.size, 3);
+      assert.strictEqual(map.size, 3 + 3);
 
       const output_path = join(create_zip_dir, 'out-8.zip');
       await create_zip(output_path, files, map, 2, true, is_windows);


### PR DESCRIPTION
This PR fixes an issue I discovered yesterday related in particular to how symlinks are handled.

If an archive (TAR) contains only files, without their parent directories, and contains a symlink which points to a parent directory, then the symlink is reported as broken by the `--dry-run` option, instead of pointing to the correct directory and mode.

With this PR, this is now fixed, and it is able to retrieve the correct parent directory mode.

For reference, I attach here an example of such kind of archive: [archive.tar.gz](https://github.com/user-attachments/files/17489386/archive.tar.gz)