### PR TITLE
fix(zip)!: store mtime with the Info-ZIP format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "tar-stream": "^3.1.7",
         "valid-filename": "^4.0.0",
         "yauzl": "^3.2.0",
-        "yazl": "^3.2.1"
+        "yazl": "^3.3.0"
       },
       "bin": {
         "node-zip-cli": "dist/index.mjs"
@@ -3026,9 +3026,9 @@
       }
     },
     "node_modules/yazl": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.2.1.tgz",
-      "integrity": "sha512-srBrMa97OdczYkvARd8nVaJrDu8vRVqzuaCfP/Fz8yQMjuUiIJchQUz5ouaoN31pp2Crk3UFblz621Q/mtp+6g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.0.tgz",
+      "integrity": "sha512-Hm7GeOfxL5XxABWgdjHa95XuiVfjLUR+N5MeOm4radbFiYTiqKiiNpbERocn0DXcuWWxv7cZ7uvZdQjxOLmUMg==",
       "dependencies": {
         "buffer-crc32": "^1.0.0"
       }
@@ -4870,9 +4870,9 @@
       }
     },
     "yazl": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.2.1.tgz",
-      "integrity": "sha512-srBrMa97OdczYkvARd8nVaJrDu8vRVqzuaCfP/Fz8yQMjuUiIJchQUz5ouaoN31pp2Crk3UFblz621Q/mtp+6g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.0.tgz",
+      "integrity": "sha512-Hm7GeOfxL5XxABWgdjHa95XuiVfjLUR+N5MeOm4radbFiYTiqKiiNpbERocn0DXcuWWxv7cZ7uvZdQjxOLmUMg==",
       "requires": {
         "buffer-crc32": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     "tar-stream": "^3.1.7",
     "valid-filename": "^4.0.0",
     "yauzl": "^3.2.0",
-    "yazl": "^3.2.1"
+    "yazl": "^3.3.0"
   }
 }

--- a/src/core/zip.ts
+++ b/src/core/zip.ts
@@ -6,7 +6,6 @@ import { pipeline } from 'node:stream/promises';
 import { logger } from '@/logger';
 import type { ArchiveEntry, CleanedEntryWithMode, FsEntry } from '@/types/fs';
 import { log_broken_symlink } from '@/utils/broken-symlink';
-import { date_from_utc, date_to_utc } from '@/utils/date';
 import {
   broken_symlinks,
   clean_path,
@@ -76,7 +75,7 @@ export const create_zip = async (
             rs,
             normalize_windows_path(file.cleaned_path, is_windows),
             {
-              mtime: date_to_utc(file.stats.mtime),
+              mtime: file.stats.mtime,
               mode: file.stats.mode,
               compress: !!deflate,
               // @ts-ignore
@@ -88,7 +87,7 @@ export const create_zip = async (
           zip.addEmptyDirectory(
             normalize_windows_path(file.cleaned_path, is_windows),
             {
-              mtime: date_to_utc(file.stats.mtime),
+              mtime: file.stats.mtime,
               mode: file.stats.mode,
             }
           );
@@ -112,7 +111,7 @@ export const create_zip = async (
             rs,
             normalize_windows_path(file.cleaned_path, is_windows),
             {
-              mtime: date_to_utc(file.stats.mtime),
+              mtime: file.stats.mtime,
               mode: file.stats.mode,
               compress: !!deflate,
               // @ts-ignore
@@ -161,7 +160,7 @@ export const read_zip = async (
         cleaned_path: clean_path(normalize(path)),
         type,
         stats: {
-          mtime: date_from_utc(entry.getLastModDate()),
+          mtime: entry.getLastModDate(),
           uid: 1000,
           gid: 1000,
           mode: mode || get_default_mode(type),
@@ -220,7 +219,7 @@ export const extract_zip = async (
             : 'file';
 
         if (type === 'file' || type === 'directory' || type === 'symlink') {
-          const mtime = date_from_utc(entry.getLastModDate());
+          const mtime = entry.getLastModDate();
 
           /* c8 ignore next 14 */
           const path = remove_trailing_sep(entry.fileName, '/');

--- a/test/core/zip.test.ts
+++ b/test/core/zip.test.ts
@@ -23,11 +23,11 @@ const archives_dir = join(process.cwd(), 'test', '_archives_');
 
 const format_date = (date: Date) => {
   // In the zip archive the mtime has milliseconds set to 0
-  // and seconds as a multiple of 2
+  // and seconds as a multiple of 1 (Info-ZIP format)
   //
   // So to be able to compare dates we need to ensure
   // that they are in the same format
-  return new Date(Math.floor(date.getTime() / 2000) * 2000);
+  return new Date(Math.floor(date.getTime() / 1000) * 1000);
 };
 
 const compare_date = (value: Date, compare_to: Date) => {


### PR DESCRIPTION
This PR takes advantage of a change introduced with version `3.3.0` of `yazl`
In particular, it uses now the Info-ZIP format to represent the `mtime` of a file/symlink/directory, which stores the time in UTC

From `yazl` documentation:
Since `yazl` version 3.3.0, `yazl` includes the Info-ZIP "universal timestamp" extended field (0x5455 aka "UT") to encode the `mtime`
The benefits of the Info-ZIP encoding include:
  - timezone is specified as always UTC
  - capable of encoding "time 0", the unix epoch in 1970
  - the precision is 1-second accurate rather than rounded to the nearest even second.

The disadvantage of including this field are:
  - it requires an extra 9 bytes of metadata per entry added to the archive.